### PR TITLE
Add patch/stride and text length controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ We provide preprocessed data in the ./data folder to accelerate training, partic
 #Conduct experiments on the health dataset using GPU 0, and utilize the 0th to 1st models.
 bash ./scripts/week_health.sh.sh 0 1 0
 ```
+- For electronic health record tasks (48h IHM prediction and 24h phenotype classification),
+  use `scripts/run_ehr.py` with `--ehr_task ihm` or `--ehr_task pheno`. The script combines PatchTST with a Llama text encoder and reports AUROC/AUPRC/F1 metrics. PatchTST patch parameters (`--patch_len`, `--stride`) and the Llama tokenizer length (`--max_text_len`) can be tuned via command line.
 - You can set a list of model names, prediction lengths, and random seeds in the script for batch experiments. We recommend specifying `--save_name` to better organize and save the results.
 - `--llm_model` can set as LLAMA2, LLAMA3, GPT2, BERT, GPT2M, GPT2L, GPT2XL, Doc2Vec, ClosedLLM. When using ClosedLLM, you need to do Step 3 at first.
 - `--pool_type` can set as avg min max attention for different pooling ways of token. When `--pool_type` is set to attention, we use the output of the time series model to calculate attention scores for each token in the LLM output and perform weighted aggregation.

--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -1,5 +1,6 @@
 from data_provider.data_loader import Dataset_Custom, Dataset_M4, PSMSegLoader, \
     MSLSegLoader, SMAPSegLoader, SMDSegLoader, SWATSegLoader, UEAloader
+from data_provider.p2x_loader import P2XDataset
 from data_provider.uea import collate_fn
 from torch.utils.data import DataLoader
 
@@ -11,7 +12,8 @@ data_dict = {
     'SMAP': SMAPSegLoader,
     'SMD': SMDSegLoader,
     'SWAT': SWATSegLoader,
-    'UEA': UEAloader
+    'UEA': UEAloader,
+    'p2x': P2XDataset
 }
 
 

--- a/data_provider/p2x_loader.py
+++ b/data_provider/p2x_loader.py
@@ -1,0 +1,36 @@
+import pickle
+from torch.utils.data import Dataset
+import torch
+
+class P2XDataset(Dataset):
+    """Dataset for p2x EHR classification tasks."""
+
+    def __init__(self, pkl_path: str, task: str):
+        """Load dataset from ``pkl_path``.
+
+        Parameters
+        ----------
+        pkl_path : str
+            Path to pickle file containing a list of dictionaries.
+        task : {'ihm', 'pheno'}
+            Downstream task type.
+        """
+        with open(pkl_path, 'rb') as f:
+            self.data = pickle.load(f)
+        self.task = task
+        self.seq_len = self.data[0]['reg_ts'].shape[0]
+        self.num_features = 17
+        self.num_classes = 24 if task == 'pheno' else 2
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        item = self.data[idx]
+        ts = torch.tensor(item['reg_ts'][:, :self.num_features], dtype=torch.float32)
+        text = ' '.join(item['text_data'])
+        if self.task == 'pheno':
+            label = torch.tensor(item['label'][1:25], dtype=torch.float32)
+        else:
+            label = torch.tensor(item['label'], dtype=torch.long)
+        return ts, text, label

--- a/exp/exp_ehr.py
+++ b/exp/exp_ehr.py
@@ -1,0 +1,158 @@
+from exp.exp_basic import Exp_Basic
+from data_provider.p2x_loader import P2XDataset
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer, AutoModel
+from sklearn.metrics import roc_auc_score, average_precision_score, f1_score
+import torch
+import torch.nn as nn
+import numpy as np
+import os
+from types import SimpleNamespace
+from models.PatchTST import Model as PatchTST
+
+
+def compute_metrics(task, trues, preds):
+    y_true = torch.cat(trues, dim=0).cpu().numpy()
+    y_pred = torch.cat(preds, dim=0)
+    metrics = {}
+    if task == 'pheno':
+        y_score = torch.sigmoid(y_pred).cpu().numpy()
+        pred_label = (y_score > 0.5).astype(int)
+        metrics['macro_AUROC'] = roc_auc_score(y_true, y_score, average='macro')
+        metrics['macro_AUPRC'] = average_precision_score(y_true, y_score, average='macro')
+        metrics['micro_F1'] = f1_score(y_true, pred_label, average='micro')
+        metrics['macro_F1'] = f1_score(y_true, pred_label, average='macro')
+    else:
+        probs = torch.softmax(y_pred, dim=1).cpu().numpy()
+        pred_label = (probs[:,1] > 0.5).astype(int)
+        metrics['macro_AUROC'] = roc_auc_score(y_true, probs[:,1])
+        metrics['macro_AUPRC'] = average_precision_score(y_true, probs[:,1])
+        metrics['micro_F1'] = f1_score(y_true, pred_label, average='micro')
+        metrics['macro_F1'] = f1_score(y_true, pred_label, average='macro')
+    return metrics
+
+
+class Exp_EHR(Exp_Basic):
+    def __init__(self, args):
+        self.task = args.ehr_task
+        pkl = os.path.join(args.data_root, self.task, 'train_p2x_data.pkl')
+        tmp_ds = P2XDataset(pkl, self.task)
+        args.seq_len = tmp_ds.seq_len
+        args.num_class = tmp_ds.num_classes
+        super().__init__(args)
+        self.tokenizer = AutoTokenizer.from_pretrained(args.llm_model_path, token=args.huggingface_token)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.text_model = AutoModel.from_pretrained(args.llm_model_path, token=args.huggingface_token).to(self.device)
+        self.text_model.eval()
+        self.text_proj = nn.Linear(self.text_model.config.hidden_size, self.args.num_class).to(self.device)
+
+    def _build_model(self):
+        cfg = SimpleNamespace(
+            task_name='classification',
+            seq_len=self.args.seq_len,
+            pred_len=self.args.seq_len,
+            enc_in=17,
+            num_class=self.args.num_class,
+            d_model=self.args.d_model,
+            n_heads=self.args.n_heads,
+            e_layers=self.args.e_layers,
+            d_layers=1,
+            d_ff=self.args.d_ff,
+            dropout=self.args.dropout,
+            factor=self.args.factor,
+            embed='timeF',
+            activation='gelu',
+            output_attention=False,
+            distil=True,
+        )
+        model = PatchTST(
+            cfg,
+            patch_len=self.args.patch_len,
+            stride=self.args.stride,
+        ).float()
+        if self.args.use_multi_gpu and self.args.use_gpu:
+            model = nn.DataParallel(model, device_ids=self.args.device_ids)
+        return model
+
+    def _get_data(self, flag):
+        pkl = os.path.join(self.args.data_root, self.task, f"{flag}_p2x_data.pkl")
+        ds = P2XDataset(pkl, self.task)
+        loader = DataLoader(ds, batch_size=self.args.batch_size, shuffle=(flag=='train'))
+        return ds, loader
+
+    def _select_optimizer(self):
+        return torch.optim.Adam(list(self.model.parameters())+list(self.text_proj.parameters()), lr=self.args.learning_rate)
+
+    def _select_criterion(self):
+        if self.task == 'pheno':
+            return nn.BCEWithLogitsLoss()
+        else:
+            return nn.CrossEntropyLoss()
+
+    def train(self, setting):
+        train_data, train_loader = self._get_data('train')
+        self.args.seq_len = train_data.seq_len
+        self.args.num_class = train_data.num_classes
+        self.model = self._build_model().to(self.device)
+        vali_data, vali_loader = self._get_data('val')
+        test_data, test_loader = self._get_data('test')
+        optimizer = self._select_optimizer()
+        criterion = self._select_criterion()
+        for epoch in range(self.args.train_epochs):
+            self.model.train(); self.text_proj.train()
+            losses = []
+            for ts, texts, labels in train_loader:
+                ts = ts.to(self.device)
+                labels = labels.to(self.device)
+                with torch.no_grad():
+                    tokens = self.tokenizer(
+                        list(texts),
+                        return_tensors='pt',
+                        padding=True,
+                        truncation=True,
+                        max_length=self.args.max_text_len,
+                    ).input_ids.to(self.device)
+                    emb = self.text_model.get_input_embeddings()(tokens).mean(dim=1)
+                logits = self.model(ts, None, None, None) + self.text_proj(emb)
+                loss = criterion(logits, labels)
+                optimizer.zero_grad(); loss.backward(); optimizer.step()
+                losses.append(loss.item())
+            train_loss = np.average(losses)
+            val_loss, val_metrics = self.evaluation(vali_loader, criterion)
+            print(f"Epoch {epoch+1}: train_loss={train_loss:.3f} val_loss={val_loss:.3f} val_metrics={val_metrics}")
+        test_loss, test_metrics = self.evaluation(test_loader, criterion)
+        print('Test metrics:', test_metrics)
+        return self.model
+
+    def evaluation(self, loader, criterion):
+        self.model.eval(); self.text_proj.eval()
+        losses = []; preds=[]; trues=[]
+        with torch.no_grad():
+            for ts, texts, labels in loader:
+                ts = ts.to(self.device)
+                labels = labels.to(self.device)
+                tokens = self.tokenizer(
+                    list(texts),
+                    return_tensors='pt',
+                    padding=True,
+                    truncation=True,
+                    max_length=self.args.max_text_len,
+                ).input_ids.to(self.device)
+                emb = self.text_model.get_input_embeddings()(tokens).mean(dim=1)
+                logits = self.model(ts, None, None, None) + self.text_proj(emb)
+                loss = criterion(logits, labels)
+                losses.append(loss.item())
+                preds.append(logits.cpu())
+                trues.append(labels.cpu())
+        loss = np.average(losses)
+        metrics = compute_metrics(self.task, trues, preds)
+        self.model.train(); self.text_proj.train()
+        return loss, metrics
+
+    def test(self, setting, test=0):
+        _, loader = self._get_data('test')
+        criterion = self._select_criterion()
+        loss, metrics = self.evaluation(loader, criterion)
+        print('Test metrics:', metrics)
+        return

--- a/scripts/run_ehr.py
+++ b/scripts/run_ehr.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from exp.exp_ehr import Exp_EHR
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_root', type=str, default='sampledata', help='dataset root folder')
+    parser.add_argument('--ehr_task', type=str, choices=['ihm', 'pheno'], required=True)
+    parser.add_argument('--llm_model_path', type=str, default='JackFram/llama-160m')
+    parser.add_argument('--huggingface_token', type=str, default=None)
+    parser.add_argument('--max_text_len', type=int, default=256,
+                        help='maximum number of tokens for LLAMA text encoder')
+    parser.add_argument('--d_model', type=int, default=128)
+    parser.add_argument('--n_heads', type=int, default=4)
+    parser.add_argument('--e_layers', type=int, default=2)
+    parser.add_argument('--d_ff', type=int, default=256)
+    parser.add_argument('--patch_len', type=int, default=16,
+                        help='patch length for PatchTST embedding')
+    parser.add_argument('--stride', type=int, default=8,
+                        help='stride for PatchTST patch embedding')
+    parser.add_argument('--dropout', type=float, default=0.1)
+    parser.add_argument('--factor', type=int, default=1)
+    parser.add_argument('--learning_rate', type=float, default=1e-4)
+    parser.add_argument('--batch_size', type=int, default=8)
+    parser.add_argument('--train_epochs', type=int, default=1)
+    parser.add_argument('--use_gpu', action='store_true')
+    parser.add_argument('--use_multi_gpu', action='store_true')
+    parser.add_argument('--devices', type=str, default='0')
+    args = parser.parse_args()
+
+    if args.use_gpu and args.use_multi_gpu:
+        args.device_ids = [int(x) for x in args.devices.split(',')]
+        args.gpu = args.device_ids[0]
+    else:
+        args.gpu = 0
+    exp = Exp_EHR(args)
+    setting = f"ehr_{args.ehr_task}"
+    exp.train(setting)
+    exp.test(setting)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- allow configuring PatchTST patch_len and stride in `run_ehr.py`
- expose max_text_len option for LLAMA tokenizer
- document new arguments in README

## Testing
- `python scripts/run_ehr.py --data_root sampledata --ehr_task ihm --train_epochs 1 --batch_size 2 --patch_len 8 --stride 4 --max_text_len 32` *(fails: Missing scipy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684821718ac4832e8e8d9689ff8a7662