### PR TITLE
Expose PatchTST parameters in EHR runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We provide preprocessed data in the ./data folder to accelerate training, partic
 bash ./scripts/week_health.sh.sh 0 1 0
 ```
 - For electronic health record tasks (48h IHM prediction and 24h phenotype classification),
-  use `scripts/run_ehr.py` with `--ehr_task ihm` or `--ehr_task pheno`. The script combines PatchTST with a Llama text encoder and reports AUROC/AUPRC/F1 metrics.
+  use `scripts/run_ehr.py` with `--ehr_task ihm` or `--ehr_task pheno`. The script combines PatchTST with a Llama text encoder and reports AUROC/AUPRC/F1 metrics. Patch sizes (`--patch_len`, `--stride`) and tokenizer max length (`--max_seq_len`) can be configured via command line.
 - You can set a list of model names, prediction lengths, and random seeds in the script for batch experiments. We recommend specifying `--save_name` to better organize and save the results.
 - `--llm_model` can set as LLAMA2, LLAMA3, GPT2, BERT, GPT2M, GPT2L, GPT2XL, Doc2Vec, ClosedLLM. When using ClosedLLM, you need to do Step 3 at first.
 - `--pool_type` can set as avg min max attention for different pooling ways of token. When `--pool_type` is set to attention, we use the output of the time series model to calculate attention scores for each token in the LLM output and perform weighted aggregation.

--- a/exp/exp_ehr.py
+++ b/exp/exp_ehr.py
@@ -66,7 +66,7 @@ class Exp_EHR(Exp_Basic):
             output_attention=False,
             distil=True,
         )
-        model = PatchTST(cfg).float()
+        model = PatchTST(cfg, patch_len=self.args.patch_len, stride=self.args.stride).float()
         if self.args.use_multi_gpu and self.args.use_gpu:
             model = nn.DataParallel(model, device_ids=self.args.device_ids)
         return model
@@ -102,7 +102,7 @@ class Exp_EHR(Exp_Basic):
                 ts = ts.to(self.device)
                 labels = labels.to(self.device)
                 with torch.no_grad():
-                    tokens = self.tokenizer(list(texts), return_tensors='pt', padding=True, truncation=True, max_length=256).input_ids.to(self.device)
+                    tokens = self.tokenizer(list(texts), return_tensors='pt', padding=True, truncation=True, max_length=self.args.max_seq_len).input_ids.to(self.device)
                     emb = self.text_model.get_input_embeddings()(tokens).mean(dim=1)
                 logits = self.model(ts, None, None, None) + self.text_proj(emb)
                 loss = criterion(logits, labels)
@@ -122,7 +122,7 @@ class Exp_EHR(Exp_Basic):
             for ts, texts, labels in loader:
                 ts = ts.to(self.device)
                 labels = labels.to(self.device)
-                tokens = self.tokenizer(list(texts), return_tensors='pt', padding=True, truncation=True, max_length=256).input_ids.to(self.device)
+                tokens = self.tokenizer(list(texts), return_tensors='pt', padding=True, truncation=True, max_length=self.args.max_seq_len).input_ids.to(self.device)
                 emb = self.text_model.get_input_embeddings()(tokens).mean(dim=1)
                 logits = self.model(ts, None, None, None) + self.text_proj(emb)
                 loss = criterion(logits, labels)

--- a/scripts/run_ehr.py
+++ b/scripts/run_ehr.py
@@ -12,12 +12,18 @@ def main():
     parser.add_argument('--ehr_task', type=str, choices=['ihm', 'pheno'], required=True)
     parser.add_argument('--llm_model_path', type=str, default='JackFram/llama-160m')
     parser.add_argument('--huggingface_token', type=str, default=None)
+    parser.add_argument('--max_seq_len', type=int, default=256,
+                        help='max sequence length for tokenizer')
     parser.add_argument('--d_model', type=int, default=128)
     parser.add_argument('--n_heads', type=int, default=4)
     parser.add_argument('--e_layers', type=int, default=2)
     parser.add_argument('--d_ff', type=int, default=256)
     parser.add_argument('--dropout', type=float, default=0.1)
     parser.add_argument('--factor', type=int, default=1)
+    parser.add_argument('--patch_len', type=int, default=16,
+                        help='patch length for PatchTST')
+    parser.add_argument('--stride', type=int, default=8,
+                        help='patch stride for PatchTST')
     parser.add_argument('--learning_rate', type=float, default=1e-4)
     parser.add_argument('--batch_size', type=int, default=8)
     parser.add_argument('--train_epochs', type=int, default=1)


### PR DESCRIPTION
## Summary
- add patch length, stride and max text seq len options in `scripts/run_ehr.py`
- propagate these args in `exp/exp_ehr.py`
- document new options in README

## Testing
- `python scripts/run_ehr.py --ehr_task ihm --llm_model_path sshleifer/tiny-gpt2 --patch_len 8 --stride 4 --max_seq_len 32 --train_epochs 0 --batch_size 1`

------
https://chatgpt.com/codex/tasks/task_e_684869a12c28832eb5a79f928da776ee