### PR TITLE
Enhance EHR text branch pooling

### DIFF
--- a/scripts/run_ehr.py
+++ b/scripts/run_ehr.py
@@ -8,7 +8,7 @@ from exp.exp_ehr import Exp_EHR
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data_root', type=str, default='/home/ubuntu/hcy50662/output_mimic3', help='dataset root folder')
+    parser.add_argument('--data_root', type=str, default=os.environ.get('DATA_ROOT', '/home/ubuntu/hcy50662/output_mimic3'), help='dataset root folder')
     parser.add_argument('--ehr_task', type=str, default='pheno', choices=['ihm', 'pheno'])
     parser.add_argument('--llm_model_path', type=str, default='meta-llama/Meta-Llama-3-8B-Instruct')
     parser.add_argument('--huggingface_token', type=str, default="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")
@@ -25,6 +25,10 @@ def main():
     parser.add_argument('--stride', type=int, default=2,
                         help='patch stride for PatchTST')
     parser.add_argument('--learning_rate', type=float, default=1e-4)
+    parser.add_argument('--mlp_learning_rate', type=float, default=1e-4, help='learning rate for text MLP')
+    parser.add_argument('--use_full_model', action='store_true', help='use full text model instead of only embeddings')
+    parser.add_argument('--pool_type', type=str, default='avg', choices=['avg', 'max', 'attention'],
+                        help='pooling method for text branch')
     parser.add_argument('--batch_size', type=int, default=8)
     parser.add_argument('--train_epochs', type=int, default=5000)
     parser.add_argument('--use_gpu', action='store_true')


### PR DESCRIPTION
## Summary
- apply token-level MLP before pooling in EHR experiment
- add optional avg/max/attention pooling
- expose `pool_type` argument in `run_ehr.py`

## Testing
- `python scripts/run_ehr.py --data_root sampledata --train_epochs 1 --batch_size 2 --llm_model_path hf-internal-testing/tiny-random-gpt2 --pool_type avg --use_full_model --mlp_learning_rate 1e-4 --max_seq_len 256`

------
https://chatgpt.com/codex/tasks/task_e_68494deb2b64832ebccc6a469426dca0